### PR TITLE
Fix create-react-app support typescript 5 bug

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -71,5 +71,8 @@
     "lint-staged": "^13.2.3",
     "prettier": "2.8.4",
     "typescript": "^5.1.6"
+  },
+  "overrides": {
+    "typescript": "^5.1.6"
   }
 }


### PR DESCRIPTION
<img width="712" alt="image" src="https://github.com/Kartm/lunni/assets/39482722/db9244fa-9675-4f80-8ebe-d83e79f58ec1">
https://github.com/facebook/create-react-app/issues/13080